### PR TITLE
bump ffi version to 1.15.3

### DIFF
--- a/cld2.gemspec
+++ b/cld2.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = CLD::VERSION
 
-  gem.add_dependency "ffi", "~> 1.9.18"
+  gem.add_dependency "ffi", "~> 1.15.3"
 
   gem.add_development_dependency "rspec", "~> 3.7.0"
 end


### PR DESCRIPTION
The ffi gem does not appear to play nicely on M1 chip Macbooks. This PR updates to the current latest version.